### PR TITLE
fix prop: wrong parsing of large integers

### DIFF
--- a/actualizar.py
+++ b/actualizar.py
@@ -92,7 +92,7 @@ def construir_datos() -> pd.core.frame.DataFrame:
             # Estadísticas de estudiantes
             nodos = html.select(selectores["estudiantes"])
             for i, campo in enumerate(campos["estudiantes"]):
-                tabla = pd.read_html(str(nodos[i]))[0]
+                tabla = pd.read_html(str(nodos[i]), decimal=',', thousands='.')[0]
                 tabla = tabla.set_index("Sexo").unstack()
                 tabla.index = tabla.index.map(lambda x: f"{campo}_{x[1].lower()}_{x[0]}")
                 datos_unidad.append(tabla.to_dict())


### PR DESCRIPTION
buenas,
revisando los datos hay un error en como parsea enteros que usan `.` para separar los miles, [por ej](https://seie.minedu.gob.bo/reportes/mapas_unidades_educativas/ficha/ver/81730079) los matriculados totales el 2017 en el raw esta como `1.093` en vez de `1093.0`
no probe el fix, pero creo que deberia funcionar